### PR TITLE
Add benchmarks, improve perf

### DIFF
--- a/bench.js
+++ b/bench.js
@@ -1,0 +1,26 @@
+const Benchmark = require('benchmark');
+
+global.require = require;
+
+function setup() {
+  let Encoder = require('./lib/encoder');
+  let Parser  = require('./lib/parser');
+  let encoder = new Encoder({ prefix: 'TEST', lengthFormat: 'UInt8' });
+  let parser  = new Parser({ prefix: 'TEST', lengthFormat: 'UInt8' });
+
+  encoder.write('Hello World');
+
+  let message = encoder.read();
+
+  parser.on( 'message', function() {} );
+}
+
+function fn() {
+  parser.write( message );
+}
+
+const bench = new Benchmark( 'parse', { setup, fn } );
+
+bench.on( 'complete', () => console.log( bench.toString() ) );
+
+bench.run();

--- a/lib/message.js
+++ b/lib/message.js
@@ -44,6 +44,19 @@ class Message {
   }
 
   /**
+   * Reset the internal state to we can start consuming a new message
+   * @method reset
+   * @return {Undefined}
+   */
+
+  reset() {
+    this.message = null;
+    this.messageOffset = 0;
+    this.headerOffset = 0;
+    this.length = 0;
+  }
+
+  /**
    * Is this message valid and complete?
    *
    * @method valid
@@ -51,7 +64,7 @@ class Message {
    */
 
   get valid() {
-    return this.message && this.messageOffset === this.length;
+    return this.message !== null && this.messageOffset === this.length;
   }
 
   /**
@@ -62,7 +75,7 @@ class Message {
    */
 
   toBuffer() {
-    return this.message.slice();
+    return this.message;
   }
 
   /**
@@ -76,98 +89,88 @@ class Message {
    */
 
   consume( chunk, offset ) {
-    // attempt read to header and get number of bytes consumed
-    const bytes = this.consumeHeader( chunk, offset, chunk.length );
+    const chunkLen = chunk.length;
 
-    // try to initialize the internal buffer if we have a full header
-    this.startMessage();
+    let {
+      lengthFormat,
+      prefix,
+      prefixLength,
+      header,
+      headerOffset,
+      headerLength,
+      message,
+      messageOffset,
+      length,
+      maxSize
+    } = this;
 
-    // read to message and return total bytes consumed
-    return bytes + this.consumeMessage( chunk, offset + bytes, chunk.length );
-  }
+    // total number of bytes consumed
+    let read = 0;
 
-  /**
-   * Attempt to consume a chunk portion to fill the header buffer,
-   * and return the number of bytes consumed
-   *
-   * @method consumeHeader
-   * @param  {Buffer}      chunk  – input chunk
-   * @param  {Nunber}      offset – input chunk read offset
-   * @param  {Nunber}      length – input chunk byte length
-   * @return {number}             – bytes consumed
-   */
+    // consume header bytes
+    if ( headerOffset < headerLength ) {
+      const remaining = headerLength - headerOffset;
 
-  consumeHeader( chunk, offset, length ) {
-    if ( this.headerOffset < this.headerLength ) {
-      const remaining = this.headerLength - this.headerOffset;
-      const bytes     = Math.min( remaining, length - offset );
+      read = Math.min( remaining, chunkLen - offset );
 
-      chunk.copy( this.header, this.headerOffset, offset, offset + bytes );
+      chunk.copy( header, headerOffset, offset, offset + read );
 
-      this.headerOffset += bytes;
+      headerOffset = this.headerOffset = headerOffset + read;
 
-      return bytes;
+      offset = offset + read;
     }
 
-    return 0;
-  }
-
-  /**
-   * Initialize internal buffer if a full header has been read
-   *
-   * @method startMessage
-   * @return {Undefined}
-   */
-
-  startMessage() {
-    if ( this.headerOffset === this.headerLength && !this.message ) {
+    // initialize a new message buffer
+    if ( headerOffset === headerLength && message === null ) {
       // the sent prefix
-      const prefix = this.header.toString( 'utf8', 0, this.prefixLength );
+      const _prefix = header.toString( 'utf8', 0, prefixLength );
 
-      if ( prefix !== this.prefix ) {
-        throw new Error( `Invalid message prefix: ${ prefix }` );
+      if ( _prefix !== prefix ) {
+        return new Error( `Invalid message prefix: ${ prefix }` );
       }
 
-      const method = `read${ this.lengthFormat }`;
-
-      this.length = this.header[ method ]( this.prefixLength );
-
-      if ( this.length === 0 ) {
-        throw new Error('0-length message received');
+      switch ( lengthFormat ) {
+        case 'UInt8':
+          length = this.length = header.readUInt8( prefixLength );
+          break;
+        case 'UInt16LE':
+          length = this.length = header.readUInt16LE( prefixLength );
+          break;
+        case 'UInt16BE':
+          length = this.length = header.readUInt16BE( prefixLength );
+          break;
+        case 'UInt32LE':
+          length = this.length = header.readUInt32LE( prefixLength );
+          break;
+        case 'UInt32BE':
+          length = this.length = header.readUInt32BE( prefixLength );
+          break;
       }
 
-      if ( this.length > this.maxSize ) {
-        throw new Error( `Message length exceeds max of ${ this.maxSize }` );
+      if ( length === 0 ) {
+        return new Error('0-length message received');
       }
 
-      this.message = Buffer.alloc( this.length );
-    }
-  }
+      if ( length > maxSize ) {
+        return new Error( `Message length exceeds max of ${ this.maxSize }` );
+      }
 
-  /**
-   * Attempt to consume a chunk portion to fill the message buffer,
-   * and return the number of bytes consumed
-   *
-   * @method consumeHeader
-   * @param  {Buffer}      chunk  – input chunk
-   * @param  {Nunber}      offset – input chunk read offset
-   * @param  {Nunber}      length – input chunk byte length
-   * @return {number}             – bytes consumed
-   */
-
-  consumeMessage( chunk, offset, length ) {
-    if ( this.message && offset < length ) {
-      const remaining = this.length - this.messageOffset;
-      const bytes     = Math.min( remaining, length - offset );
-
-      chunk.copy( this.message, this.messageOffset, offset, offset + bytes );
-
-      this.messageOffset += bytes;
-
-      return bytes;
+      message = this.message = Buffer.allocUnsafe( length ).fill( 0 );
     }
 
-    return 0;
+    // consume message bytes
+    if ( message !== null && offset < chunkLen ) {
+      const remaining = length - messageOffset;
+      const bytes     = Math.min( remaining, chunkLen - offset );
+
+      chunk.copy( message, messageOffset, offset, offset + bytes );
+
+      this.messageOffset = messageOffset + bytes;
+
+      read = read + bytes;
+    }
+
+    return read;
   }
 
   /**
@@ -183,12 +186,32 @@ class Message {
       payload = Buffer.from( payload, 'utf8' );
     }
 
-    const buffer = Buffer.alloc( this.headerLength + payload.length );
-    const method = `write${ this.lengthFormat }`;
+    const { lengthFormat, headerLength, prefixLength, prefix } = this;
 
-    buffer.write( this.prefix );
-    buffer[ method ]( payload.length, this.prefixLength );
-    payload.copy( buffer, this.headerLength );
+    const length = payload.length;
+    const buffer = Buffer.allocUnsafe( headerLength + length ).fill( 0 );
+
+    buffer.write( prefix );
+
+    switch ( lengthFormat ) {
+      case 'UInt8':
+        buffer.writeUInt8( length, prefixLength );
+        break;
+      case 'UInt16LE':
+        buffer.writeUInt16LE( length, prefixLength );
+        break;
+      case 'UInt16BE':
+        buffer.writeUInt16BE( length, prefixLength );
+        break;
+      case 'UInt32LE':
+        buffer.writeUInt32LE( length, prefixLength );
+        break;
+      case 'UInt32BE':
+        buffer.writeUInt32BE( length, prefixLength );
+        break;
+    }
+
+    payload.copy( buffer, headerLength );
 
     return buffer;
   }

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -51,6 +51,9 @@ class Parser extends Transform {
    */
 
   _transform( chunk, encoding, done ) {
+    const message = this.message;
+    const length  = chunk.length;
+
     let offset = 0;
 
     if ( typeof chunk === 'string' ) {
@@ -58,22 +61,22 @@ class Parser extends Transform {
     }
 
     while ( true ) {
-      try {
-        offset += this.message.consume( chunk, offset );
-      } catch ( ex ) {
-        return done( ex );
+      const result = message.consume( chunk, offset );
+
+      if ( typeof result !== 'number' ) {
+        return done( result );
       }
 
-      if ( this.message.valid ) {
+      offset = offset + result;
+
+      if ( message.valid ) {
         this.finish();
       }
 
-      if ( offset >= chunk.length ) {
-        break;
+      if ( offset >= length ) {
+        return done();
       }
     }
-
-    done();
   }
 
   /**
@@ -102,7 +105,7 @@ class Parser extends Transform {
     const buffer     = this.message.toBuffer();
     const translated = this.translate( buffer );
 
-    this.message = new Message( this.format );
+    this.message.reset();
 
     super.push( buffer );
 

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   },
   "homepage": "https://github.com/StarryInternet/fringe",
   "devDependencies": {
+    "benchmark": "^2.1.4",
     "chai": "3.5.0",
     "eslint-config-starry": "^2.0.1",
     "eslint-plugin-starry": "^2.0.1",
@@ -42,7 +43,8 @@
     "node": ">=6.0.0"
   },
   "scripts": {
-    "test": "eslint lib/* && nyc mocha test/**/*"
+    "test": "eslint lib/* && nyc mocha test/**/*",
+    "bench": "node bench.js"
   },
   "main": "index.js"
 }

--- a/test/tests/3-integration.js
+++ b/test/tests/3-integration.js
@@ -3,6 +3,36 @@ const rewire = require('rewire');
 
 describe( 'Integration Tests', () => {
 
+  const formats = [
+    'UInt8',
+    'UInt16LE',
+    'UInt16BE',
+    'UInt32LE',
+    'UInt32BE'
+  ];
+
+  formats.forEach( lengthFormat => {
+
+    it( `should support ${ lengthFormat } lengths`, () => {
+      const Encoder = rewire('../../lib/encoder');
+      const Parser  = rewire('../../lib/parser');
+
+      const encode = new Encoder({ lengthFormat });
+      const parse  = new Parser({ lengthFormat });
+
+      encode.write('Hello World');
+
+      const encoded = encode.read();
+
+      parse.write( encoded );
+
+      const decoded = parse.read();
+
+      assert.equal( decoded.toString(), 'Hello World' );
+    });
+
+  });
+
   it( 'should parse severely chunked messages', () => {
     const Encoder = rewire('../../lib/encoder');
     const Parser  = rewire('../../lib/parser');


### PR DESCRIPTION
Code isn't as pretty now – but this is a pretty significant perf improvement.

Fringe can now handle over half a million incoming messages per second on my MBP.

Basic improvements:

1. Use `buffer.allocUnsafe( length ).fill( 0 )` instead of `buffer.alloc( length )`
2. `+=` on an identifier that was declared with `let` cannot currently be optimized in V8, so I rm'd those.
3. Inline everything into `Message#consume` in order to share a bunch of variables and prevent extra property lookups.
4. Don't dynamically construct the `readUInt8` strings. `switch` is significantly faster.
5. Reuse a single `Message` per `Parser`. This cuts down on allocations pretty significantly.