### PR TITLE
More performance enhancements:

### DIFF
--- a/lib/message.js
+++ b/lib/message.js
@@ -33,6 +33,8 @@ class Message {
     this.headerLength = this.prefixLength + formats[ this.lengthFormat ];
     // header buffer
     this.header = Buffer.alloc( this.headerLength );
+    // do we have a full header?
+    this.foundHeader = false;
     // message buffer (once full header is received)
     this.message = null;
     // current write offset within this.message
@@ -53,6 +55,7 @@ class Message {
     this.message = null;
     this.messageOffset = 0;
     this.headerOffset = 0;
+    this.foundHeader = false;
     this.length = 0;
   }
 
@@ -101,27 +104,33 @@ class Message {
       message,
       messageOffset,
       length,
-      maxSize
+      maxSize,
+      foundHeader
     } = this;
 
     // total number of bytes consumed
     let read = 0;
 
     // consume header bytes
-    if ( headerOffset < headerLength ) {
+    if ( !foundHeader ) {
       const remaining = headerLength - headerOffset;
 
       read = Math.min( remaining, chunkLen - offset );
 
-      chunk.copy( header, headerOffset, offset, offset + read );
+      // fats path for complete header
+      if ( read === headerLength ) {
+        header = chunk.slice( offset, offset + read );
+      } else {
+        chunk.copy( header, headerOffset, offset, offset + read );
+      }
 
       headerOffset = this.headerOffset = headerOffset + read;
 
       offset = offset + read;
     }
 
-    // initialize a new message buffer
-    if ( headerOffset === headerLength && message === null ) {
+    // initialize internal stage for a new a new message
+    if ( headerOffset === headerLength && !foundHeader ) {
       // the sent prefix
       const _prefix = header.toString( 'utf8', 0, prefixLength );
 
@@ -155,15 +164,25 @@ class Message {
         return new Error( `Message length exceeds max of ${ this.maxSize }` );
       }
 
-      message = this.message = Buffer.allocUnsafe( length ).fill( 0 );
+      foundHeader = this.foundHeader = true;
     }
 
     // consume message bytes
-    if ( message !== null && offset < chunkLen ) {
+    if ( foundHeader && offset < chunkLen ) {
       const remaining = length - messageOffset;
       const bytes     = Math.min( remaining, chunkLen - offset );
 
-      chunk.copy( message, messageOffset, offset, offset + bytes );
+      // fast path for fresh, complete messages
+      if ( bytes === length ) {
+        this.message = chunk.slice( offset, offset + bytes );
+        this.messageOffset = bytes;
+        return read + bytes;
+      } else {
+        if ( message === null ) {
+          message = this.message = Buffer.allocUnsafe( length ).fill( 0 );
+        }
+        chunk.copy( message, messageOffset, offset, offset + bytes );
+      }
 
       this.messageOffset = messageOffset + bytes;
 

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -107,7 +107,7 @@ class Parser extends Transform {
 
     this.message.reset();
 
-    super.push( buffer );
+    this.push( buffer );
 
     this.emit( 'message', translated );
   }


### PR DESCRIPTION
1. Fast-path complete messages
2. Don't use a `super` call to `push()` when I can just use `this.push()`

This gets us up from ~530k ops/sec to more like ~650k ope/sec.

The fast-path thing is about using `Buffer#slice()` instead of allocating a whole new buffer. `slice` is fast because it doesn't actually allocate more memory for the underlying bytes – it simply creates a new _view_ into the existing memory.

The `super` thing just came from grinding through flame graphs. The calling function (`Parser#finish()`) was taking way longer than it seemed like it should have – so I tried swapping `super.oush()` for `this.push()` call and it made a pretty big difference.