### PR TITLE
add lengthModifier to format

### DIFF
--- a/lib/message.js
+++ b/lib/message.js
@@ -9,9 +9,10 @@ const formats = {
 
 // default settings
 const defaults = {
-  prefix:       'FRINGE',
-  lengthFormat: 'UInt32BE',
-  maxSize:      1024 * 1024 * 100
+  prefix:           'FRINGE',
+  lengthFormat:     'UInt32BE',
+  maxSize:          1024 * 1024 * 100,
+  lengthModifier:   0
 };
 
 class Message {
@@ -105,7 +106,8 @@ class Message {
       messageOffset,
       length,
       maxSize,
-      foundHeader
+      foundHeader,
+      lengthModifier
     } = this;
 
     // total number of bytes consumed
@@ -140,19 +142,19 @@ class Message {
 
       switch ( lengthFormat ) {
         case 'UInt8':
-          length = this.length = header.readUInt8( prefixLength );
+          length = header.readUInt8( prefixLength );
           break;
         case 'UInt16LE':
-          length = this.length = header.readUInt16LE( prefixLength );
+          length = header.readUInt16LE( prefixLength );
           break;
         case 'UInt16BE':
-          length = this.length = header.readUInt16BE( prefixLength );
+          length = header.readUInt16BE( prefixLength );
           break;
         case 'UInt32LE':
-          length = this.length = header.readUInt32LE( prefixLength );
+          length = header.readUInt32LE( prefixLength );
           break;
         case 'UInt32BE':
-          length = this.length = header.readUInt32BE( prefixLength );
+          length = header.readUInt32BE( prefixLength );
           break;
       }
 
@@ -165,6 +167,13 @@ class Message {
       }
 
       foundHeader = this.foundHeader = true;
+
+      // in some versions of V8, using += with a `let` declared variable
+      // causes the engine to deopt; so we're writing this the long way
+      //
+      // https://github.com/vhf/v8-bailout-reasons
+      // ( Unsupported let compound assignment )
+      this.length = length = length + lengthModifier;
     }
 
     // consume message bytes
@@ -205,28 +214,31 @@ class Message {
       payload = Buffer.from( payload, 'utf8' );
     }
 
-    const { lengthFormat, headerLength, prefixLength, prefix } = this;
+    const {
+      lengthModifier, lengthFormat, headerLength, prefixLength, prefix
+    } = this;
 
     const length = payload.length;
     const buffer = Buffer.allocUnsafe( headerLength + length ).fill( 0 );
+    const lengthBytes = length - lengthModifier;
 
     buffer.write( prefix );
 
     switch ( lengthFormat ) {
       case 'UInt8':
-        buffer.writeUInt8( length, prefixLength );
+        buffer.writeUInt8( lengthBytes, prefixLength );
         break;
       case 'UInt16LE':
-        buffer.writeUInt16LE( length, prefixLength );
+        buffer.writeUInt16LE( lengthBytes, prefixLength );
         break;
       case 'UInt16BE':
-        buffer.writeUInt16BE( length, prefixLength );
+        buffer.writeUInt16BE( lengthBytes, prefixLength );
         break;
       case 'UInt32LE':
-        buffer.writeUInt32LE( length, prefixLength );
+        buffer.writeUInt32LE( lengthBytes, prefixLength );
         break;
       case 'UInt32BE':
-        buffer.writeUInt32BE( length, prefixLength );
+        buffer.writeUInt32BE( lengthBytes, prefixLength );
         break;
     }
 

--- a/test/tests/1-encoder.js
+++ b/test/tests/1-encoder.js
@@ -24,7 +24,7 @@ describe( 'Encoder', () => {
 
   describe( '#_transform', () => {
 
-    it( 'accept an string and return a buffer with prefix and length', done => {
+    it( 'accept a string and return a buffer with prefix and length', done => {
       const Encoder = rewire( path );
       // `objectMode: true` prevents the stream from converting our string to
       // buffer so that we can get coverage on passing strings to `_transform`
@@ -38,6 +38,32 @@ describe( 'Encoder', () => {
         assert.equal( header, 'FRINGE' );
         assert.equal( len, 5 );
 
+        done();
+      });
+
+      encoder.write( text );
+    });
+
+    it( 'should modify the length if length modifier has been set', done => {
+      const Encoder = rewire( path );
+      const encoder = new Encoder( { lengthModifier: 2 }, { objectMode: true } );
+      const text   = 'hello';
+
+      encoder.on( 'data', chunk => {
+        assert.equal( chunk.readUInt32BE( 6 ), 3 );
+        done();
+      });
+
+      encoder.write( text );
+    });
+
+    it( 'should not modify the length if length modifier hasnt been set', done => {
+      const Encoder = rewire( path );
+      const encoder = new Encoder( {}, { objectMode: true } );
+      const text   = 'hello';
+
+      encoder.on( 'data', chunk => {
+        assert.equal( chunk.readUInt32BE( 6 ), 5 );
         done();
       });
 

--- a/test/tests/2-parser.js
+++ b/test/tests/2-parser.js
@@ -311,6 +311,42 @@ describe( 'Parser', () => {
       encoder.write( text );
     });
 
+    it( 'should read extra bytes when length modifier is set', done => {
+      const Parser  = rewire( parserPath );
+      const parser  = new Parser({ lengthModifier: 2 });
+
+      // create a buffer with an insufficient length integer
+      const buf = Buffer.alloc( 14 );
+      let offset = buf.write('FRINGE');
+      offset = buf.writeUInt32BE( 2, offset );
+      offset = buf.write( 'hihi', offset );
+
+      parser.on( 'message', msg => {
+        assert.equal( msg.toString(), 'hihi' );
+        done();
+      });
+
+      parser.write( buf );
+    });
+
+    it( 'should not read extra bytes when length modifier is 0', done => {
+      const Parser  = rewire( parserPath );
+      const parser  = new Parser();
+
+      // create a buffer with an insufficient length integer
+      const buf = Buffer.alloc( 14 );
+      let offset = buf.write('FRINGE');
+      offset = buf.writeUInt32BE( 2, offset );
+      offset = buf.write( 'hihi', offset );
+
+      parser.on( 'message', msg => {
+        assert.equal( msg.toString(), 'hi' );
+        done();
+      });
+
+      parser.write( buf );
+    });
+
   });
 
 });


### PR DESCRIPTION
Purpose of this PR:

- Add a property to the `format` configuration object called `lengthModifier`

This adds some interop flexibility to `fringe` such that it can deal with protocols where the `length` field in the header don't always encapsulate the entire byte stream payload; e.g. tacking on a CRC block after the message payload that isn't accounted for in the header `length` field.

This prop tells `fringe` to continue reading `N` bytes from the stream after `length` has been fulfilled (where `N=lengthModifier`)